### PR TITLE
Balance bullet columns for resume

### DIFF
--- a/src/components/Resume.tsx
+++ b/src/components/Resume.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ResumeData, ResumeConfig, defaultResumeConfig } from '../types/resume';
+import { pairItemsByLength } from '../utils/bulletUtils';
 
 // Add this type override at the top of the file (after imports):
 type FlexibleField = string | { value: string; fixed?: boolean; editable?: boolean };
@@ -120,6 +121,7 @@ export default function Resume({
   const coreCompetenciesArr = getArrayValue(resumeData.coreCompetencies);
   const coreItems = coreCompetenciesArr.slice(0, 10);
   while (coreItems.length < 10) coreItems.push('');
+  const orderedCoreItems = pairItemsByLength(coreItems);
 
   // Get education and certifications arrays properly
   const educationArray = getEducationArray(resumeData.education);
@@ -193,11 +195,10 @@ export default function Resume({
           <section className={`mb-3.5${highlightSections.includes('coreCompetencies') ? ' ring-2 ring-green-400 bg-green-50 transition-all duration-500' : ''}`}>
             <h2 className="section-header text-[16px]">Core Competencies</h2>
             <ul className="grid grid-cols-2 gap-x-6 text-[12px] ml-3">
-              {coreCompetenciesArr.map((item: string, i: number) => (
+              {orderedCoreItems.map((item: string, i: number) => (
                 <li key={i} className="flex items-start mb-0.5">
                   <span className="w-1.5 h-1.5 bg-black rounded-full mt-1.5 mr-1.5 flex-shrink-0"></span>
-                  {/* No truncation, no wrapping, one line only */}
-                  <span className="leading-snug whitespace-nowrap overflow-x-auto block" style={{maxWidth: '95%'}}>{getFieldValue(item)}</span>
+                  <span className="leading-snug whitespace-nowrap overflow-hidden block" style={{maxWidth: '95%'}}>{getFieldValue(item)}</span>
                 </li>
               ))}
             </ul>

--- a/src/components/ResumeDocument.tsx
+++ b/src/components/ResumeDocument.tsx
@@ -10,6 +10,7 @@ import {
 import path from 'path';
 import { ResumeConfig, defaultResumeConfig } from '../types/resume';
 import defaultResumeData from '../../data/resume.json';
+import { pairItemsByLength } from '../utils/bulletUtils';
 
 type FlexibleField = string | { value: string; fixed?: boolean; editable?: boolean };
 
@@ -145,7 +146,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     marginBottom: 3,
     alignItems: 'flex-start',
-    paddingRight: 32,
+    paddingRight: 16,
   },
   bullet: {
     width: 4,
@@ -160,10 +161,7 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 11.2,
     lineHeight: 1.32,
-    // Prevent wrapping and add ellipsis for overflow
-    whiteSpace: 'nowrap',
     overflow: 'hidden',
-    textOverflow: 'ellipsis',
     maxWidth: '95%',
   },
   experienceItem: {
@@ -289,6 +287,7 @@ export default function ResumeDocument({ resumeData, config }: ResumeDocumentPro
   const coreCompetenciesArray = getArrayValue(data.coreCompetencies);
   const coreItems = coreCompetenciesArray.slice(0, 10);
   while (coreItems.length < 10) coreItems.push('');
+  const orderedCoreItems = pairItemsByLength(coreItems);
 
   // Get education and certifications arrays properly
   const educationArray = getEducationArray(data.education);
@@ -342,7 +341,7 @@ export default function ResumeDocument({ resumeData, config }: ResumeDocumentPro
           <View style={styles.section}>
             <Text style={styles.sectionHeader}>Core Competencies</Text>
             <View style={styles.competenciesGrid}>
-              {coreCompetenciesArray.map((item: string, i: number) => (
+              {orderedCoreItems.map((item: string, i: number) => (
                 <View key={i} style={styles.competencyItem}>
                   <View style={styles.bullet} />
                   {/* Force single-line bullet for PDF, no truncation */}

--- a/src/utils/bulletUtils.ts
+++ b/src/utils/bulletUtils.ts
@@ -1,0 +1,13 @@
+export function pairItemsByLength(items: string[], pairs = 5): string[] {
+  const arr = items.slice(0, pairs * 2);
+  while (arr.length < pairs * 2) arr.push('');
+  arr.sort((a, b) => b.length - a.length);
+  const result: string[] = [];
+  while (arr.length) {
+    const first = arr.shift() as string;
+    const second = arr.pop() ?? '';
+    result.push(first, second);
+  }
+  return result;
+}
+


### PR DESCRIPTION
## Summary
- add utility to pair core competency bullets by length
- reorder bullet lists in web and PDF components using new helper
- trim PDF bullet styles to prevent wrapping

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eef61cbdc832982ce3b89238998dd